### PR TITLE
shallow: handle multiple return values from method calls

### DIFF
--- a/typed-racket-test/succeed/shallow/object-untyped.rkt
+++ b/typed-racket-test/succeed/shallow/object-untyped.rkt
@@ -6,10 +6,12 @@
   (define c%
     (class object%
       (super-new)
-      (define/public (f x) '(+ x 1))))
+      (define/public (f x) '(+ x 1))
+      (define/public (g x) (values (+ 4 4) x))))
   (provide c%))
 
-(define-type C% (Class (f (-> Integer Integer))))
+(define-type C% (Class (f (-> Integer Integer))
+                       (g (-> Integer (Values Integer Integer)))))
 
 (require typed/rackunit)
 (require/typed (submod "." u)
@@ -23,3 +25,5 @@
 (check-exn exn:fail:contract?
   (lambda () (g (vector (new c%)))))
 
+(check-not-exn
+  (lambda () (define-values {a b} (send (new c%) g 5)) (void)))


### PR DESCRIPTION
Discovered today that shallow didn't support multiple returns from methods.

I basically imitated what the regular app case does to handle multiple return values, but I may have missed something or done something wrong. It does pass the new test I added (which failed before fixing). But running the full TR tests seems to report failures even without these changes so not sure if there's a special setup to do there that I'm missing?

@bennn can you look this over? If it's OK I'd like to rerun the experiment with the fix.
